### PR TITLE
feat: `language` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,17 @@ Language addition requests are welcome through Issues or Pull Requests.
 #### Examples
 
 ```bash
-# Basic scan with table output (default)
-techscan ./project
+# Scan languages with table output (default)
+techscan lang ./project
 
-# JSON format output
-techscan ./project --reporter json
+# Scan languages with JSON output
+techscan lang ./project --reporter json
 
-# Exclude specific file patterns
-techscan ./project --exclude "*.test.ts" --exclude "node_modules"
+# Scan languages with exclude specific file patterns
+techscan lang ./project --exclude "*.test.ts" --exclude "node_modules"
 
 # Multiple excludes with short option
-techscan ./project -e "*.test.ts" -e "*.spec.ts" -e "dist"
-
-# Combined options
-techscan ./project --reporter json --exclude "*.test.*"
+techscan lang ./project -e "*.test.ts" -e "*.spec.ts" -e "dist"
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cargo install techscan
 
 ## CLI
 
-### Scan programin languages
+### Scan programming languages
 
 ```bash
 techscan lang ./project

--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 `techscan` is a Rust CLI tool for analyzing and visualizing technology stacks in a directory.
 
-## Usage
+## Install
 
 ### Cargo
 
 ```bash
-# Install techscan
 cargo install techscan
+```
 
-# Run techscan
-techscan ./project
+## CLI
+
+### Scan programin languages
+
+```bash
+techscan lang ./project
 
 === Scan Summary ===
 ┌─────────────┬────────────────────┐
@@ -38,11 +42,10 @@ techscan ./project
 │ Python     │ 1     │ 3.6%       │
 │ CSS        │ 1     │ 3.6%       │
 │ C          │ 1     │ 3.6%       │
-│ Total      │ 28    │ 100.0%     │
 └────────────┴───────┴────────────┘
 ```
 
-## Supported Languages
+#### Supported Languages
 
 Astro, C, C++, C#, COBOL, CSS, Dart, Elixir, Go, Haskell, HTML, Java, JavaScript, Kotlin, Lua, Objective-C, Perl, PHP, Python, R, Ruby, Rust, Scala, SCSS, Shell, Svelte, Swift, TypeScript, Vue
 
@@ -50,16 +53,16 @@ Astro, C, C++, C#, COBOL, CSS, Dart, Elixir, Go, Haskell, HTML, Java, JavaScript
 
 Language addition requests are welcome through Issues or Pull Requests.
 
-## CLI Options
+### CLI Options
 
-### Options
+#### Options
 
 | Option | Short | Description | Default | Example |
 |--------|-------|-------------|---------|---------|
 | `--reporter` | `-r` | Output format: `table`, `json` | `table` | `--reporter json` |
 | `--exclude` | `-e` | Exclude path patterns (can be used multiple times) | - | `--exclude "*.test.ts"` |
 
-### Examples
+#### Examples
 
 ```bash
 # Basic scan with table output (default)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use config::{Config, ConfigError, File};
 use serde::Deserialize;
 
@@ -6,21 +6,30 @@ use serde::Deserialize;
 #[command(name = "techscan")]
 #[command(about = "A tool for analyzing and visualizing technology stacks in codes.")]
 pub struct Cli {
-    #[arg(help = "Directory path to scan")]
-    pub dir: String,
+    #[command(subcommand)]
+    pub command: Commands,
+}
 
-    #[arg(
-        short,
-        long,
-        help = "Exclude path patterns (can be used multiple times)"
-    )]
-    pub exclude: Option<Vec<String>>,
+#[derive(Subcommand)]
+pub enum Commands {
+    #[command(visible_alias = "lang")]
+    Language {
+        #[arg(help = "Directory path to analyze")]
+        dir: String,
 
-    #[arg(short, long, help = "Output format: table, json [default: table]")]
-    pub reporter: Option<String>,
+        #[arg(
+            short,
+            long,
+            help = "Exclude path patterns (can be used multiple times)"
+        )]
+        exclude: Option<Vec<String>>,
 
-    #[arg(short, long, help = "Config file path")]
-    pub config: Option<String>,
+        #[arg(short, long, help = "Output format: table, json [default: table]")]
+        reporter: Option<String>,
+
+        #[arg(short, long, help = "Config file path")]
+        config: Option<String>,
+    },
 }
 
 #[derive(Deserialize, Default)]
@@ -31,28 +40,38 @@ pub struct AppConfig {
 
 impl Cli {
     pub fn new() -> Result<Self, ConfigError> {
-        let mut cli = Self::parse();
-
-        if let Some(config_path) = &cli.config {
-            let config_data = cli.load_config_file(config_path)?;
-
-            if cli.exclude.is_none() && config_data.exclude.is_some() {
-                cli.exclude = config_data.exclude;
-            }
-
-            if cli.reporter.is_none() && config_data.reporter.is_some() {
-                cli.reporter = config_data.reporter;
-            }
-        }
-
-        Ok(cli)
+        Ok(Self::parse())
     }
 
-    fn load_config_file(&self, path: &str) -> Result<AppConfig, ConfigError> {
+    pub fn load_config_file(&self, path: &str) -> Result<AppConfig, ConfigError> {
         let config = Config::builder()
             .add_source(File::with_name(path))
             .build()?;
 
         config.try_deserialize()
+    }
+
+    pub fn apply_config(
+        &self,
+        config_path: &Option<String>,
+        exclude: &mut Option<Vec<String>>,
+        reporter: &mut Option<String>,
+    ) -> Result<(), String> {
+        if let Some(path) = config_path {
+            match self.load_config_file(path) {
+                Ok(config_data) => {
+                    if exclude.is_none() && config_data.exclude.is_some() {
+                        *exclude = config_data.exclude;
+                    }
+                    if reporter.is_none() && config_data.reporter.is_some() {
+                        *reporter = config_data.reporter;
+                    }
+                    Ok(())
+                }
+                Err(_) => Err(format!("Failed to load config file: {}", path)),
+            }
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/entity/language_report.rs
+++ b/src/entity/language_report.rs
@@ -2,14 +2,14 @@ use crate::entity::Language;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ScannerReport {
+pub struct LanguageReport {
     pub dir: String,
     pub total_file_count: u64,
-    pub languages: Vec<ScannerLanguage>,
+    pub languages: Vec<LanguageReportItem>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ScannerLanguage {
+pub struct LanguageReportItem {
     pub language: Language,
     pub file_count: u64,
     pub file_paths: Vec<String>,

--- a/src/entity/language_scanner_options.rs
+++ b/src/entity/language_scanner_options.rs
@@ -1,4 +1,4 @@
 #[derive(Default)]
-pub struct ScannerOptions {
+pub struct LanguageScannerOptions {
     pub exclude: Vec<String>,
 }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -1,9 +1,9 @@
 pub mod file;
 pub mod language;
-pub mod scanner_options;
-pub mod scanner_report;
+pub mod language_report;
+pub mod language_scanner_options;
 
 pub use file::File;
 pub use language::Language;
-pub use scanner_options::ScannerOptions;
-pub use scanner_report::{ScannerLanguage, ScannerReport};
+pub use language_report::{LanguageReport, LanguageReportItem};
+pub use language_scanner_options::LanguageScannerOptions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ mod service;
 
 use crate::cli::{Cli, Commands};
 use crate::config::REPORTER_FORMAT_TABLE;
-use crate::entity::ScannerOptions;
-use crate::service::{Reporter, Scanner};
+use crate::entity::LanguageScannerOptions;
+use crate::service::{LanguageReporter, LanguageScanner};
 
 fn main() {
     let cli = Cli::new().unwrap_or_else(|e| {
@@ -47,16 +47,16 @@ fn handle_language_command(
         .as_deref()
         .unwrap_or(REPORTER_FORMAT_TABLE);
 
-    Reporter::validate_format(reporter_format).unwrap_or_else(|e| {
+    LanguageReporter::validate_format(reporter_format).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     });
 
-    let opts = ScannerOptions {
+    let opts = LanguageScannerOptions {
         exclude: exclude_patterns.unwrap_or_default(),
     };
 
-    let scanner = Scanner::new(dir.clone(), Some(opts)).unwrap_or_else(|e| {
+    let scanner = LanguageScanner::new(dir.clone(), Some(opts)).unwrap_or_else(|e| {
         eprintln!("Error initializing scanner: {}", e);
         std::process::exit(1);
     });
@@ -70,7 +70,7 @@ fn handle_language_command(
 
     let report = scanner.analyze(files);
 
-    let reporter = Reporter::new();
+    let reporter = LanguageReporter::new();
 
     reporter
         .output(&report, reporter_format)

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
 }
 
 fn handle_language_command(
-    dir: &String,
+    dir: &str,
     exclude: &Option<Vec<String>>,
     reporter: &Option<String>,
     config: &Option<String>,
@@ -56,7 +56,7 @@ fn handle_language_command(
         exclude: exclude_patterns.unwrap_or_default(),
     };
 
-    let scanner = LanguageScanner::new(dir.clone(), Some(opts)).unwrap_or_else(|e| {
+    let scanner = LanguageScanner::new(dir, Some(opts)).unwrap_or_else(|e| {
         eprintln!("Error initializing scanner: {}", e);
         std::process::exit(1);
     });

--- a/src/service/language_reporter.rs
+++ b/src/service/language_reporter.rs
@@ -1,18 +1,18 @@
 use crate::config::{REPORTER_FORMAT_JSON, REPORTER_FORMAT_TABLE};
-use crate::entity::ScannerReport;
+use crate::entity::LanguageReport;
 use std::io;
 use tabled::builder::Builder;
 use tabled::settings::{object::Rows, Alignment, Modify, Style};
 
-pub struct Reporter;
+pub struct LanguageReporter;
 
-impl Default for Reporter {
+impl Default for LanguageReporter {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Reporter {
+impl LanguageReporter {
     pub fn new() -> Self {
         Self
     }
@@ -27,7 +27,7 @@ impl Reporter {
         }
     }
 
-    pub fn output(&self, report: &ScannerReport, format: &str) -> io::Result<()> {
+    pub fn output(&self, report: &LanguageReport, format: &str) -> io::Result<()> {
         Self::validate_format(format)?;
 
         let output_string = match format {
@@ -40,12 +40,12 @@ impl Reporter {
         Ok(())
     }
 
-    fn to_json(&self, report: &ScannerReport) -> io::Result<String> {
+    fn to_json(&self, report: &LanguageReport) -> io::Result<String> {
         serde_json::to_string_pretty(report)
             .map_err(|e| io::Error::other(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_table(&self, report: &ScannerReport) -> io::Result<String> {
+    fn to_table(&self, report: &LanguageReport) -> io::Result<String> {
         let mut output = Vec::new();
 
         let mut summary_builder = Builder::default();
@@ -92,21 +92,21 @@ impl Reporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::entity::{Language, ScannerLanguage};
+    use crate::entity::{Language, LanguageReportItem};
 
-    fn create_test_report() -> ScannerReport {
+    fn create_test_report() -> LanguageReport {
         let language = Language {
             name: "Rust",
             exts: &["rs"],
         };
 
-        let language_report = ScannerLanguage {
+        let language_report = LanguageReportItem {
             language,
             file_count: 5,
             file_paths: vec!["src/main.rs".to_string(), "src/lib.rs".to_string()],
         };
 
-        ScannerReport {
+        LanguageReport {
             dir: "/test/path".to_string(),
             total_file_count: 5,
             languages: vec![language_report],
@@ -115,12 +115,12 @@ mod tests {
 
     #[test]
     fn test_validate_format_valid() {
-        assert!(Reporter::validate_format("table").is_ok());
+        assert!(LanguageReporter::validate_format("table").is_ok());
     }
 
     #[test]
     fn test_validate_format_invalid() {
-        let result = Reporter::validate_format("xml");
+        let result = LanguageReporter::validate_format("xml");
         assert!(result.is_err());
 
         let error_msg = result.unwrap_err().to_string();
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_to_json_success() {
-        let reporter = Reporter::new();
+        let reporter = LanguageReporter::new();
         let report = create_test_report();
 
         let result = reporter.to_json(&report);

--- a/src/service/language_scanner.rs
+++ b/src/service/language_scanner.rs
@@ -14,8 +14,8 @@ pub struct LanguageScanner {
 }
 
 impl LanguageScanner {
-    pub fn new(dir: String, opts: Option<LanguageScannerOptions>) -> io::Result<Self> {
-        if !Path::new(&dir).exists() {
+    pub fn new(dir: &str, opts: Option<LanguageScannerOptions>) -> io::Result<Self> {
+        if !Path::new(dir).exists() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("Directory does not exist: {}", dir),
@@ -24,7 +24,10 @@ impl LanguageScanner {
 
         let opts = opts.map_or_else(LanguageScannerOptions::default, |o| o);
 
-        Ok(Self { dir, opts })
+        Ok(Self {
+            dir: dir.to_string(),
+            opts,
+        })
     }
 
     pub fn scan(&self) -> io::Result<Vec<File>> {
@@ -134,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_scan_cli_fixture() {
-        let scanner = LanguageScanner::new("tests/fixtures/cli".to_string(), None)
+        let scanner = LanguageScanner::new("tests/fixtures/cli", None)
             .expect("LanguageScanner creation should succeed for existing directory");
 
         let files = scanner.scan().expect("Scanning should succeed");
@@ -162,7 +165,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Directory does not exist")]
     fn test_scanner_nonexistent_directory() {
-        LanguageScanner::new("nonexistent/directory".to_string(), None).expect("This should panic");
+        LanguageScanner::new("nonexistent/directory", None).expect("This should panic");
     }
 
     #[test]
@@ -171,7 +174,7 @@ mod tests {
             exclude: vec!["*.rs".to_string()],
         };
 
-        let scanner = LanguageScanner::new("tests/fixtures/cli".to_string(), Some(opts))
+        let scanner = LanguageScanner::new("tests/fixtures/cli", Some(opts))
             .expect("LanguageScanner creation should succeed");
 
         let files = scanner.scan().expect("Scanning should succeed");
@@ -193,7 +196,7 @@ mod tests {
             exclude: vec!["*.rs".to_string(), "*.js".to_string(), "*.rb".to_string()],
         };
 
-        let scanner = LanguageScanner::new("tests/fixtures/cli".to_string(), Some(opts))
+        let scanner = LanguageScanner::new("tests/fixtures/cli", Some(opts))
             .expect("LanguageScanner creation should succeed");
 
         let files = scanner.scan().expect("Scanning should succeed");

--- a/src/service/language_scanner.rs
+++ b/src/service/language_scanner.rs
@@ -1,6 +1,6 @@
 use crate::config::LanguageConfig;
-use crate::entity::ScannerOptions;
-use crate::entity::{File, ScannerLanguage, ScannerReport};
+use crate::entity::LanguageScannerOptions;
+use crate::entity::{File, LanguageReport, LanguageReportItem};
 use ignore::{overrides::OverrideBuilder, Walk, WalkBuilder};
 use std::collections::HashMap;
 use std::io;
@@ -8,13 +8,13 @@ use std::path::Path;
 
 const GLOBAL_EXCLUDE_PATH: [&str; 2] = [".git", ".DS_Store"];
 
-pub struct Scanner {
+pub struct LanguageScanner {
     dir: String,
-    opts: ScannerOptions,
+    opts: LanguageScannerOptions,
 }
 
-impl Scanner {
-    pub fn new(dir: String, opts: Option<ScannerOptions>) -> io::Result<Self> {
+impl LanguageScanner {
+    pub fn new(dir: String, opts: Option<LanguageScannerOptions>) -> io::Result<Self> {
         if !Path::new(&dir).exists() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
@@ -22,7 +22,7 @@ impl Scanner {
             ));
         }
 
-        let opts = opts.map_or_else(ScannerOptions::default, |o| o);
+        let opts = opts.map_or_else(LanguageScannerOptions::default, |o| o);
 
         Ok(Self { dir, opts })
     }
@@ -53,7 +53,7 @@ impl Scanner {
         Ok(files)
     }
 
-    pub fn analyze(&self, files: Vec<File>) -> ScannerReport {
+    pub fn analyze(&self, files: Vec<File>) -> LanguageReport {
         let mut language_data: HashMap<String, Vec<String>> = HashMap::new();
 
         for file in &files {
@@ -71,7 +71,7 @@ impl Scanner {
         let mut languages = Vec::new();
         for (lang_name, file_paths) in language_data {
             if let Some(language) = LanguageConfig::get_language_by_name(&lang_name) {
-                languages.push(ScannerLanguage {
+                languages.push(LanguageReportItem {
                     language,
                     file_count: file_paths.len() as u64,
                     file_paths,
@@ -81,7 +81,7 @@ impl Scanner {
 
         languages.sort_by(|a, b| b.file_count.cmp(&a.file_count));
 
-        ScannerReport {
+        LanguageReport {
             dir: self.dir.clone(),
             total_file_count: files.len() as u64,
             languages,
@@ -134,8 +134,8 @@ mod tests {
 
     #[test]
     fn test_scan_cli_fixture() {
-        let scanner = Scanner::new("tests/fixtures/cli".to_string(), None)
-            .expect("Scanner creation should succeed for existing directory");
+        let scanner = LanguageScanner::new("tests/fixtures/cli".to_string(), None)
+            .expect("LanguageScanner creation should succeed for existing directory");
 
         let files = scanner.scan().expect("Scanning should succeed");
 
@@ -162,17 +162,17 @@ mod tests {
     #[test]
     #[should_panic(expected = "Directory does not exist")]
     fn test_scanner_nonexistent_directory() {
-        Scanner::new("nonexistent/directory".to_string(), None).expect("This should panic");
+        LanguageScanner::new("nonexistent/directory".to_string(), None).expect("This should panic");
     }
 
     #[test]
     fn test_scan_with_exclude_pattern() {
-        let opts = ScannerOptions {
+        let opts = LanguageScannerOptions {
             exclude: vec!["*.rs".to_string()],
         };
 
-        let scanner = Scanner::new("tests/fixtures/cli".to_string(), Some(opts))
-            .expect("Scanner creation should succeed");
+        let scanner = LanguageScanner::new("tests/fixtures/cli".to_string(), Some(opts))
+            .expect("LanguageScanner creation should succeed");
 
         let files = scanner.scan().expect("Scanning should succeed");
 
@@ -189,12 +189,12 @@ mod tests {
 
     #[test]
     fn test_scan_with_multiple_exclude_patterns() {
-        let opts = ScannerOptions {
+        let opts = LanguageScannerOptions {
             exclude: vec!["*.rs".to_string(), "*.js".to_string(), "*.rb".to_string()],
         };
 
-        let scanner = Scanner::new("tests/fixtures/cli".to_string(), Some(opts))
-            .expect("Scanner creation should succeed");
+        let scanner = LanguageScanner::new("tests/fixtures/cli".to_string(), Some(opts))
+            .expect("LanguageScanner creation should succeed");
 
         let files = scanner.scan().expect("Scanning should succeed");
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,5 @@
-pub mod reporter;
-pub mod scanner;
+pub mod language_reporter;
+pub mod language_scanner;
 
-pub use reporter::Reporter;
-pub use scanner::Scanner;
+pub use language_reporter::LanguageReporter;
+pub use language_scanner::LanguageScanner;


### PR DESCRIPTION
- resolve: https://github.com/kimulaco/techscan/issues/5
- Migrated language scanning to the `language` (`lang`) subcommand