### PR TITLE
feat: add `TechScanError` and `Result`

### DIFF
--- a/src/entity/error.rs
+++ b/src/entity/error.rs
@@ -1,4 +1,4 @@
-use config::ConfigError;
+use ::config::ConfigError;
 use std::fmt;
 use std::io;
 

--- a/src/entity/error.rs
+++ b/src/entity/error.rs
@@ -1,0 +1,44 @@
+use config::ConfigError;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum TechScanError {
+    IoError(io::Error),
+    ConfigError(ConfigError),
+    ValidationError(String),
+    DirectoryNotFound(String),
+}
+
+impl fmt::Display for TechScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TechScanError::IoError(err) => write!(f, "I/O error: {}", err),
+            TechScanError::ConfigError(err) => write!(f, "Configuration error: {}", err),
+            TechScanError::ValidationError(msg) => write!(f, "Validation error: {}", msg),
+            TechScanError::DirectoryNotFound(path) => write!(f, "Directory not found: {}", path),
+        }
+    }
+}
+
+impl std::error::Error for TechScanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TechScanError::IoError(err) => Some(err),
+            TechScanError::ConfigError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for TechScanError {
+    fn from(err: io::Error) -> Self {
+        TechScanError::IoError(err)
+    }
+}
+
+impl From<ConfigError> for TechScanError {
+    fn from(err: ConfigError) -> Self {
+        TechScanError::ConfigError(err)
+    }
+}

--- a/src/entity/language_scanner_options.rs
+++ b/src/entity/language_scanner_options.rs
@@ -1,4 +1,4 @@
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct LanguageScannerOptions {
     pub exclude: Vec<String>,
 }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -1,11 +1,15 @@
 pub mod app_config;
+pub mod error;
 pub mod file;
 pub mod language;
 pub mod language_report;
 pub mod language_scanner_options;
+pub mod result;
 
 pub use app_config::AppConfig;
+pub use error::TechScanError;
 pub use file::File;
 pub use language::Language;
 pub use language_report::{LanguageReport, LanguageReportItem};
 pub use language_scanner_options::LanguageScannerOptions;
+pub use result::Result;

--- a/src/entity/result.rs
+++ b/src/entity/result.rs
@@ -1,0 +1,3 @@
+use crate::entity::TechScanError;
+
+pub type Result<T> = std::result::Result<T, TechScanError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@ pub mod config;
 pub mod entity;
 pub mod service;
 
-pub use entity::{File, Language, LanguageReport, LanguageReportItem, LanguageScannerOptions};
+pub use entity::{
+    File, Language, LanguageReport, LanguageReportItem, LanguageScannerOptions, Result,
+    TechScanError,
+};
 
 pub use config::{LanguageConfig, REPORTER_FORMAT_JSON, REPORTER_FORMAT_TABLE};
 


### PR DESCRIPTION
resolve: https://github.com/kimulaco/techscan/issues/12

- Add tachScan specific `Result` and `Error` (`TechScanError`)
- Change `LanguageScanner::scan()` to return specific `Result` and `TechScanError`