### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   check_pinact:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2


### PR DESCRIPTION
Potential fix for [https://github.com/kimulaco/techscan/security/code-scanning/6](https://github.com/kimulaco/techscan/security/code-scanning/6)

To fix this issue, you should add a `permissions` block to the `check_pinact` job that grants the least privileges required. Since this job only uses external actions (`actions/checkout` and `suzuki-shunsuke/pinact-action`), and is unlikely to require any write access, the best possible default is:

```yaml
permissions:
  contents: read
```

You should add this block immediately under `runs-on: ubuntu-latest` (line 13→14), following YAML indentation. No other code or behavior needs to change, and there’s no need for any package additions, imports, etc.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
